### PR TITLE
feat(core): add NoAuthentication services extension

### DIFF
--- a/Trelnex.Core.Api/Application.cs
+++ b/Trelnex.Core.Api/Application.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Trelnex.Core.Api.Authentication;
 using Trelnex.Core.Api.Configuration;
 using Trelnex.Core.Api.Context;
 using Trelnex.Core.Api.Exceptions;
@@ -67,6 +68,12 @@ public static class Application
 
         // add the calling application
         addApplication(builder.Services, builder.Configuration, bootstrapLogger);
+
+        // validate authentication was configured
+        if (AuthenticationExtensions.IsReady is false)
+        {
+            throw new InvalidOperationException("Authentication has not been configured.");
+        }
 
         // add prometheus metrics server and http client metrics
         builder.Services.AddPrometheus(builder.Configuration);

--- a/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
+++ b/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
@@ -9,6 +9,10 @@ namespace Trelnex.Core.Api.Authentication;
 /// </summary>
 public static class AuthenticationExtensions
 {
+    private static string? _method = null;
+
+    public static bool IsReady => _method is not null;
+
     /// <summary>
     /// Add Authentication and Authorization to the <see cref="IServiceCollection"/>.
     /// </summary>
@@ -19,6 +23,13 @@ public static class AuthenticationExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        if (IsReady)
+        {
+            throw new InvalidOperationException($"{_method} has already been called.");
+        }
+
+        _method = nameof(AddAuthentication);
+
         services.AddInMemoryTokenCaches();
 
         // inject our security provider
@@ -27,5 +38,28 @@ public static class AuthenticationExtensions
 
         // add the permissions to the security provider
         return new PermissionsBuilder(services, configuration, securityProvider);
+    }
+
+    /// <summary>
+    /// Add Authentication and Authorization to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/>.</returns>
+    public static void NoAuthentication(
+        this IServiceCollection services)
+    {
+        if (IsReady)
+        {
+            throw new InvalidOperationException($"{_method} has already been called.");
+        }
+
+        _method = nameof(NoAuthentication);
+
+        services.AddAuthentication();
+        services.AddAuthorization();
+
+        // inject an empty security provider
+        var securityProvider = new SecurityProvider();
+        services.AddSingleton<ISecurityProvider>(securityProvider);
     }
 }


### PR DESCRIPTION
Trelnex.Core.Api was built assuming authentication and authorization. So it assumes the authentication and authorization services are injected for the web application. And the IServiceProvider is injected for Swagger. If those services are not injected, the web application will fail.

Introduce the NoAuthentication services extension. This will inject those required services, not no actual authentication or authorization is configured.