### PR TITLE
feat(core): release trelnex-core-data

### DIFF
--- a/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
+++ b/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
@@ -55,8 +55,6 @@ public static class AuthenticationExtensions
 
         _method = nameof(NoAuthentication);
 
-        services.AddHttpContextAccessor();
-
         services.AddAuthentication();
         services.AddAuthorization();
 

--- a/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
+++ b/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
@@ -55,6 +55,8 @@ public static class AuthenticationExtensions
 
         _method = nameof(NoAuthentication);
 
+        services.AddHttpContextAccessor();
+
         services.AddAuthentication();
         services.AddAuthorization();
 

--- a/Trelnex.Core.Data.Tests/Context/TestRequestContext.cs
+++ b/Trelnex.Core.Data.Tests/Context/TestRequestContext.cs
@@ -10,8 +10,7 @@ internal static class TestRequestContext
         return new RequestContext(
             ObjectId: Guid.NewGuid().ToString(),
             HttpTraceIdentifier: Guid.NewGuid().ToString(),
-            HttpRequestPath: Guid.NewGuid().ToString(),
-            HttpBearerToken: Guid.NewGuid().ToString());
+            HttpRequestPath: Guid.NewGuid().ToString());
     }
 
     /// <summary>
@@ -20,10 +19,8 @@ internal static class TestRequestContext
     /// <param name="ObjectId">Gets the unique object ID associated with the ClaimsPrincipal for this request.</param>
     /// <param name="HttpTraceIdentifier">Gets the unique identifier to represent this request in trace logs.</param>
     /// <param name="HttpRequestPath">Gets the portion of the request path that identifies the requested resource.</param>
-    /// <param name="HttpBearerToken">Gets the value for the Bearer Token Authorization Header.</param>
     private record RequestContext(
         string? ObjectId,
         string? HttpTraceIdentifier,
-        string? HttpRequestPath,
-        string? HttpBearerToken) : IRequestContext;
+        string? HttpRequestPath) : IRequestContext;
 }

--- a/Trelnex.Core.Data/Context/IRequestContext.cs
+++ b/Trelnex.Core.Data/Context/IRequestContext.cs
@@ -19,9 +19,4 @@ public interface IRequestContext
     /// Gets the portion of the request path that identifies the requested resource.
     /// </summary>
     string? HttpRequestPath { get; }
-
-    /// <summary>
-    /// Gets the value for the Bearer Token Authorization Header.
-    /// </summary>
-    string? HttpBearerToken { get; }
 }


### PR DESCRIPTION
BREAKING CHANGE: release trelnex-core-data-2.0.0

remove HttpBearerToken from IRequestContext

inject IHttpContextAccessor in the NoAuthentication path