### PR TITLE
feat(core): release trelnex-core-api

### DIFF
--- a/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
+++ b/Trelnex.Core.Api/Authentication/AuthenticationExtensions.cs
@@ -55,6 +55,8 @@ public static class AuthenticationExtensions
 
         _method = nameof(NoAuthentication);
 
+        services.AddHttpContextAccessor();
+
         services.AddAuthentication();
         services.AddAuthorization();
 

--- a/Trelnex.Core.Api/Context/RequestContextExtensions.cs
+++ b/Trelnex.Core.Api/Context/RequestContextExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web;
@@ -47,13 +46,10 @@ public static class RequestContextExtensions
 
         var httpRequestPath = httpContext?.Request.Path.Value;
 
-        var httpBearerToken = httpContext?.GetTokenAsync("access_token").GetAwaiter().GetResult();
-
         return new RequestContext(
             ObjectId: objectId,
             HttpTraceIdentifier: httpTraceIdentifier,
-            HttpRequestPath: httpRequestPath,
-            HttpBearerToken: httpBearerToken);
+            HttpRequestPath: httpRequestPath);
     }
 
     /// <summary>
@@ -62,10 +58,8 @@ public static class RequestContextExtensions
     /// <param name="ObjectId">Gets the unique object ID associated with the ClaimsPrincipal for this request.</param>
     /// <param name="HttpTraceIdentifier">Gets the unique identifier to represent this request in trace logs.</param>
     /// <param name="HttpRequestPath">Gets the portion of the request path that identifies the requested resource.</param>
-    /// <param name="HttpBearerToken">Gets the value for the Bearer Token Authorization Header.</param>
     private record RequestContext(
         string? ObjectId,
         string? HttpTraceIdentifier,
-        string? HttpRequestPath,
-        string? HttpBearerToken) : IRequestContext;
+        string? HttpRequestPath) : IRequestContext;
 }

--- a/Trelnex.Core.Api/Trelnex.Core.Api.csproj
+++ b/Trelnex.Core.Api/Trelnex.Core.Api.csproj
@@ -33,7 +33,7 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.8.1" />
         <PackageReference Include="Trelnex.Core.Client" Version="1.0.0" />
-        <PackageReference Include="Trelnex.Core.Data" Version="1.0.0" />
+        <PackageReference Include="Trelnex.Core.Data" Version="2.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BREAKING CHANGE: release trelnex-core-api-2.0.0

use updated IRequestContext from trelnex-core-data-2.0.0 that removes HttpBearerToken