### PR TITLE
#patch - exclusive locks on methods that don't support concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Deleted
 
+## [Trelnex.Core.Api:4.1.1] - 2025-01-07
+
+### Changed
+
+- Updated to [Trelnex.Core.Data:4.1.1].
+
+## [Trelnex.Core.Emulator:4.1.1] - 2025-01-07
+
+### Changed
+
+- Updated to [Trelnex.Core.Data:4.1.1].
+
+## [Trelnex.Core.Data:4.1.1] - 2025-01-07
+
+### Added
+
+- Add an exclusive lock to `ISaveCommand<TInterface>.SaveAsync()` method to ensure that only one save operation is in progress at a time.
+- Add checks to `IQueryResult<TInterface>.Delete()` and `IQueryResult<TInterface>.Update()` methods to ensure that only one `ISaveCommand<TInterface>` can be created.
+
 ## [Trelnex.Core.Api:4.1.0] - 2025-01-05
 
 ### Added
@@ -19,34 +38,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Register `CosmosCommandProviderHealthCheck` as health check for the underlying CosmosDB.
 - Register `SqlCommandProviderHealthCheck` as health check for the underlying SQL connection.
 
+## [Trelnex.Core.Data.Emulator:4.1.0] - 2025-01-05
+
+### Changed
+
+- Updated to [Trelnex.Core.Data:4.1.0].
+- Bug fixes to `InMemoryCommandProvider` for consistency with other command providers.
+
 ## [Trelnex.Core.Data:4.1.0] - 2025-01-05
 
 ### Added
 
-- Added `CosmosCommandProviderFactory` `GetStatus` method as health check for the underlying CosmosDB.
-- Added `SqlCommandProviderFactory` `GetStatus` method as health check for the underlying SQL connection.
+- Added `CosmosCommandProviderFactory.GetStatus()` method as health check for the underlying CosmosDB.
+- Added `SqlCommandProviderFactory.GetStatus()` method as health check for the underlying SQL connection.
 
 ## [Trelnex.Core.Api:4.0.0] - 2025-01-04
 
 ### Added
 
-- Added `SqlCommandProviderExtension` `AddSqlCommandProviders` `IServiceCollection` extension method
+- Added `SqlCommandProviderExtension.AddSqlCommandProviders()` `IServiceCollection` extension method
 
 ### Changed
 
+- Updated to [Trelnex.Core.Data:4.0.0].
 - Consistent naming of Cosmos (tenantId, endpointUri, databaseId, containerId) and SQL (dataSource, initialCatalog, tableName) configuration.
 
 ## [Trelnex.Core.Data:4.0.0] - 2025-01-04
 
 ### Added
 
-- Added `IQueryResult<TInterface>` as result type from `QueryCommand` `ToAsyncEnumerable`.
+- Added `IQueryResult<TInterface>` as result type from `IQueryCommand<TInterface>.ToAsyncEnumerable()`.
 - `IQueryResult<TInterface>` exposes `Delete()` method to create an `ISaveCommand<TInterface>` to delete the item.
 - `IQueryResult<TInterface>` exposes `Update()` method to create an `ISaveCommand<TInterface>` to update the item.
 
 ### Changed
 
 - `QueryCommand` `ToAsyncEnumerable` returns an `IAsyncEnumerable` of `IQueryResult<TInterface>`.
+
+## [Trelnex.Core.Data.Emulator:3.1.0] - 2025-01-03
+
+### Changed
+
+- Updated to [Trelnex.Core.Data:3.1.0].
 
 ## [Trelnex.Core.Data:3.1.0] - 2025-01-03
 
@@ -59,14 +92,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Updated to dotnet 9.0.x
-- Changed `CosmosCommandProviderExtensions` `AddCosmosCommandProviders` `IServiceCollection` extension method namespace from `Trelnex.Core.Api.Cosmos` to `Trelnex.Core.Api.CommandProviders`.
-- Changed `CosmosCommandProviderExtensions` `AddCosmosCommandProviders` `IServiceCollection` extension method to use `CosmosCommandProviderFactory`.
+- Updated to [Trelnex.Core.Data:2.0.0].
+- Changed `CosmosCommandProviderExtensions.AddCosmosCommandProviders()` `IServiceCollection` extension method namespace from `Trelnex.Core.Api.Cosmos` to `Trelnex.Core.Api.CommandProviders`.
+- Changed `CosmosCommandProviderExtensions.AddCosmosCommandProviders()` `IServiceCollection` extension method to use `CosmosCommandProviderFactory`.
 
 ## [Trelnex.Core.Data.Emulator:3.0.0] - 2025-01-02
 
 ### Changed
 
 - Updated to dotnet 9.0.x
+- Updated to [Trelnex.Core.Data:2.0.0].
 
 ## [Trelnex.Core.Data:3.0.0] - 2025-01-02
 

--- a/Trelnex.Core.Data.Tests/Commands/CreateCommandSaveTests.cs
+++ b/Trelnex.Core.Data.Tests/Commands/CreateCommandSaveTests.cs
@@ -1,5 +1,3 @@
-using Snapshooter.NUnit;
-
 namespace Trelnex.Core.Data.Tests.Commands;
 
 public class CreateCommandSaveTests

--- a/Trelnex.Core.Data.Tests/Commands/DeleteCommandSaveTests.cs
+++ b/Trelnex.Core.Data.Tests/Commands/DeleteCommandSaveTests.cs
@@ -1,5 +1,3 @@
-using Snapshooter.NUnit;
-
 namespace Trelnex.Core.Data.Tests.Commands;
 
 public class DeleteCommandTests

--- a/Trelnex.Core.Data.Tests/Commands/QueryCommandTests.cs
+++ b/Trelnex.Core.Data.Tests/Commands/QueryCommandTests.cs
@@ -537,6 +537,92 @@ public class QueryCommandTests
     }
 
     [Test]
+    public async Task QueryCommand_ToAsyncEnumerable_Delete_Delete()
+    {
+        var id = Guid.NewGuid().ToString();
+        var partitionKey = Guid.NewGuid().ToString();
+
+        var requestContext = TestRequestContext.Create();
+
+        // create our command provider
+        var commandProvider =
+            InMemoryCommandProvider.Create<ITestItem, TestItem>(
+                typeName: _typeName);
+
+        var createCommand = commandProvider.Create(
+            id: id,
+            partitionKey: partitionKey);
+
+        createCommand.Item.PublicMessage = "Public #1";
+        createCommand.Item.PrivateMessage = "Private #1";
+
+        // save it
+        await createCommand.SaveAsync(
+            requestContext: requestContext,
+            cancellationToken: default);
+
+        // query
+        var queryCommand = commandProvider.Query();
+
+        // should return first item
+        var read1 = await queryCommand.ToAsyncEnumerable().ToArrayAsync();
+
+        Assert.That(read1, Is.Not.Null);
+        Assert.That(read1, Has.Length.EqualTo(1));
+
+        // get the first item and delete
+        var deleteCommand = read1[0].Delete();
+
+        // try to delete again
+        Assert.Throws<InvalidOperationException>(
+            () => read1[0].Delete(),
+            "The Delete() method cannot be called because either the Delete() or Update() method has already been called.");
+    }
+
+    [Test]
+    public async Task QueryCommand_ToAsyncEnumerable_Delete_Update()
+    {
+        var id = Guid.NewGuid().ToString();
+        var partitionKey = Guid.NewGuid().ToString();
+
+        var requestContext = TestRequestContext.Create();
+
+        // create our command provider
+        var commandProvider =
+            InMemoryCommandProvider.Create<ITestItem, TestItem>(
+                typeName: _typeName);
+
+        var createCommand = commandProvider.Create(
+            id: id,
+            partitionKey: partitionKey);
+
+        createCommand.Item.PublicMessage = "Public #1";
+        createCommand.Item.PrivateMessage = "Private #1";
+
+        // save it
+        await createCommand.SaveAsync(
+            requestContext: requestContext,
+            cancellationToken: default);
+
+        // query
+        var queryCommand = commandProvider.Query();
+
+        // should return first item
+        var read1 = await queryCommand.ToAsyncEnumerable().ToArrayAsync();
+
+        Assert.That(read1, Is.Not.Null);
+        Assert.That(read1, Has.Length.EqualTo(1));
+
+        // get the first item and delete
+        var deleteCommand = read1[0].Delete();
+
+        // try to update
+        Assert.Throws<InvalidOperationException>(
+            () => read1[0].Update(),
+            "The Delete() method cannot be called because either the Delete() or Update() method has already been called.");
+    }
+
+    [Test]
     public async Task QueryCommand_ToAsyncEnumerable_Update()
     {
         var id = Guid.NewGuid().ToString();
@@ -592,5 +678,91 @@ public class QueryCommandTests
                 .IgnoreField("**.UpdatedDate")
                 .IgnoreField("**.ETag"));
 
+    }
+
+    [Test]
+    public async Task QueryCommand_ToAsyncEnumerable_Update_Delete()
+    {
+        var id = Guid.NewGuid().ToString();
+        var partitionKey = Guid.NewGuid().ToString();
+
+        var requestContext = TestRequestContext.Create();
+
+        // create our command provider
+        var commandProvider =
+            InMemoryCommandProvider.Create<ITestItem, TestItem>(
+                typeName: _typeName);
+
+        var createCommand = commandProvider.Create(
+            id: id,
+            partitionKey: partitionKey);
+
+        createCommand.Item.PublicMessage = "Public #1";
+        createCommand.Item.PrivateMessage = "Private #1";
+
+        // save it
+        await createCommand.SaveAsync(
+            requestContext: requestContext,
+            cancellationToken: default);
+
+        // query
+        var queryCommand = commandProvider.Query();
+
+        // should return first item
+        var read1 = await queryCommand.ToAsyncEnumerable().ToArrayAsync();
+
+        Assert.That(read1, Is.Not.Null);
+        Assert.That(read1, Has.Length.EqualTo(1));
+
+        // get the first item and update
+        var updateCommand = read1[0].Update();
+
+        // try to delete
+        Assert.Throws<InvalidOperationException>(
+            () => read1[0].Delete(),
+            "The Delete() method cannot be called because either the Delete() or Update() method has already been called.");
+    }
+
+    [Test]
+    public async Task QueryCommand_ToAsyncEnumerable_Update_Update()
+    {
+        var id = Guid.NewGuid().ToString();
+        var partitionKey = Guid.NewGuid().ToString();
+
+        var requestContext = TestRequestContext.Create();
+
+        // create our command provider
+        var commandProvider =
+            InMemoryCommandProvider.Create<ITestItem, TestItem>(
+                typeName: _typeName);
+
+        var createCommand = commandProvider.Create(
+            id: id,
+            partitionKey: partitionKey);
+
+        createCommand.Item.PublicMessage = "Public #1";
+        createCommand.Item.PrivateMessage = "Private #1";
+
+        // save it
+        await createCommand.SaveAsync(
+            requestContext: requestContext,
+            cancellationToken: default);
+
+        // query
+        var queryCommand = commandProvider.Query();
+
+        // should return first item
+        var read1 = await queryCommand.ToAsyncEnumerable().ToArrayAsync();
+
+        Assert.That(read1, Is.Not.Null);
+        Assert.That(read1, Has.Length.EqualTo(1));
+
+        // get the first item and update
+        var updateCommand = read1[0].Update();
+
+        // try to update again
+        Assert.Throws<InvalidOperationException>(
+            () => read1[0].Update(),
+            "The Update() method cannot be called because either the Delete() or Update() method has already been called.");
     }
 }

--- a/Trelnex.Core.Data.Tests/Commands/ReadCommandReadTests.cs
+++ b/Trelnex.Core.Data.Tests/Commands/ReadCommandReadTests.cs
@@ -1,5 +1,3 @@
-using Snapshooter.NUnit;
-
 namespace Trelnex.Core.Data.Tests.Commands;
 
 public class ReadCommandTests

--- a/Trelnex.Core.Data/Commands/CommandProvider.cs
+++ b/Trelnex.Core.Data/Commands/CommandProvider.cs
@@ -262,8 +262,8 @@ internal abstract partial class CommandProvider<TInterface, TItem>
                 return QueryResult<TInterface, TItem>.Create(
                     item: item,
                     validateAsyncDelegate: ValidateAsync,
-                    convertToDeleteCommand: CreateDeleteCommand,
-                    convertToUpdateCommand: CreateUpdateCommand);
+                    createDeleteCommand: CreateDeleteCommand,
+                    createUpdateCommand: CreateUpdateCommand);
             });
     }
 


### PR DESCRIPTION
- add exclusive lock to ensure that only one save operation is in progress at a time.
- add exclusive lock to ensure that only one delete / update operation can be done on a query result